### PR TITLE
refactor: use php attributes to inject dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,10 @@ code pushing to GitHub, and release creation with the specified project version.
 Ensure you have the [GitHub CLI](https://cli.github.com/) installed to utilize
 this functionality.
 
+If your WordPress site is on WP Engine, you may consider using our GitHub Action
+for automated deployments:
+[action-deploy-to-wpengine](https://github.com/somoscuatro/action-deploy-to-wpengine)
+
 ## How to Contribute
 
 Any kind of contribution is very welcome!

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
 		"squizlabs/php_codesniffer": "^3.9",
 		"szepeviktor/phpstan-wordpress": "^1.3",
 		"wp-coding-standards/wpcs": "^3.0",
+		"zorac/phpstan-php-di": "^1.0",
 		"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz/no-trailing-comma": "^1.0"
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aefaa29247827103acdb5c81a7fe2296",
+    "content-hash": "83b3f554841516890078df1b70016a04",
     "packages": [
         {
             "name": "composer/installers",
@@ -3418,6 +3418,61 @@
                 }
             ],
             "time": "2024-03-25T16:39:00+00:00"
+        },
+        {
+            "name": "zorac/phpstan-php-di",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zorac/phpstan-php-di.git",
+                "reference": "ee94768602fd74826722c95047e27c9134b6a1b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zorac/phpstan-php-di/zipball/ee94768602fd74826722c95047e27c9134b6a1b5",
+                "reference": "ee94768602fd74826722c95047e27c9134b6a1b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0",
+                "php-di/php-di": "^7.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zorac\\PhpStanPhpDI\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Rigby-Jones",
+                    "email": "mark@rigby-jones.net",
+                    "homepage": "https://mark.rigby-jones.net/"
+                }
+            ],
+            "description": "Extansion adding support for PHP-DI to PHPStan.",
+            "homepage": "https://www.github.com/zorac/phpstan-php-di/",
+            "keywords": [
+                "PHPStan",
+                "php-di"
+            ],
+            "support": {
+                "issues": "https://github.com/zorac/phpstan-php-di/issues",
+                "source": "https://github.com/zorac/phpstan-php-di/tree/1.0.0"
+            },
+            "time": "2023-07-03T17:35:52+00:00"
         },
         {
             "name": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz/no-trailing-comma",

--- a/functions.php
+++ b/functions.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 use Somoscuatro\Starter_Theme\CLI\CLI;
 use Somoscuatro\Starter_Theme\Attributes\Hook;
 
-use DI\Container;
+use DI\ContainerBuilder;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
@@ -22,7 +22,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once __DIR__ . '/autoload.php';
 
 // Setup Dependencies.
-$container = new Container();
+$builder = new ContainerBuilder();
+$builder->useAttributes( true );
+$container = $builder->build();
 
 // Register WordPress Hooks.
 ( new Hook( $container ) )->register_hooks();

--- a/src/blocks/class-block-interface.php
+++ b/src/blocks/class-block-interface.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Somoscuatro\Starter_Theme\Blocks;
 
-use DI\Container;
+use Somoscuatro\Starter_Theme\Timber;
 
 /**
  * Interface for ACF Gutenberg Blocks.
@@ -25,7 +25,7 @@ interface Block_Interface {
 	/**
 	 * Class Constructor.
 	 *
-	 * @param Container $container The PHP DI container.
+	 * @param Timber $timber The Timber Class.
 	 */
-	public function __construct( Container $container );
+	public function __construct( Timber $timber );
 }

--- a/src/blocks/class-block.php
+++ b/src/blocks/class-block.php
@@ -11,19 +11,11 @@ namespace Somoscuatro\Starter_Theme\Blocks;
 
 use Somoscuatro\Starter_Theme\Timber;
 
-use DI\Container;
-
 /**
  * Class for ACF Gutenberg Blocks.
  */
 class Block implements Block_Interface {
 
-	/**
-	 * The PHP DI Container.
-	 *
-	 * @var Container
-	 */
-	protected static $container;
 
 	/**
 	 * The Timber Class.
@@ -49,11 +41,10 @@ class Block implements Block_Interface {
 	/**
 	 * Class Constructor.
 	 *
-	 * @param Container $container The PHP DI Container.
+	 * @param Timber $timber The Timber Class.
 	 */
-	public function __construct( Container $container ) {
-		static::$container = $container;
-		static::$timber    = $container->get( 'Somoscuatro\Starter_Theme\Timber' );
+	public function __construct( Timber $timber ) {
+		static::$timber = $timber;
 	}
 
 	/**
@@ -112,19 +103,19 @@ class Block implements Block_Interface {
 	 * the trick because the block name we get won't come from the blocks
 	 * extending this class.
 	 *
-	 * @param array   $block The Gutenberg block.
-	 * @param string  $content The content of the block.
+	 * @param array   $block      The Gutenberg block.
+	 * @param string  $content    The content of the block.
 	 * @param boolean $is_preview True if in preview mode.
 	 */
 	public static function render_callback( array $block, string $content = '', $is_preview = false ) {
-		( new static( static::$container ) )->render( $block, $content, $is_preview );
+		( new static( static::$timber ) )->render( $block, $content, $is_preview );
 	}
 
 	/**
 	 * Renders Block Twig Template.
 	 *
-	 * @param array   $block The Gutenberg block.
-	 * @param string  $content The content of the block.
+	 * @param array   $block      The Gutenberg block.
+	 * @param string  $content    The content of the block.
 	 * @param boolean $is_preview True if in preview mode.
 	 */
 	public function render( array $block, string $content = '', $is_preview = false ) {
@@ -139,8 +130,8 @@ class Block implements Block_Interface {
 	/**
 	 * Sets Block Context.
 	 *
-	 * @param array   $context The Timber context.
-	 * @param array   $block The Gutenberg block.
+	 * @param array   $context    The Timber context.
+	 * @param array   $block      The Gutenberg block.
 	 * @param boolean $is_preview True if in preview mode.
 	 *
 	 * @return array The modified Timber context.
@@ -179,8 +170,8 @@ class Block implements Block_Interface {
 	 * Adds ACF Fields to Timber Context.
 	 *
 	 * @param string $block_prefix The ACF Block Prefix.
-	 * @param array  $context The Timber Context.
-	 * @param array  $fields The ACF Fields.
+	 * @param array  $context      The Timber Context.
+	 * @param array  $fields       The ACF Fields.
 	 *
 	 * @return array The Timber Context with ACF Fields.
 	 */

--- a/src/blocks/class-loader.php
+++ b/src/blocks/class-loader.php
@@ -9,7 +9,8 @@ declare(strict_types=1);
 
 namespace Somoscuatro\Starter_Theme\Blocks;
 
-use DI\Container;
+use DI\Attribute\Inject;
+use Somoscuatro\Starter_Theme\Timber;
 
 /**
  * Gutenberg Blocks loader.
@@ -19,18 +20,11 @@ class Loader {
 	/**
 	 * The PHP DI Container.
 	 *
-	 * @var Container
+	 * @var Timber
 	 */
-	private $container;
+	#[Inject]
+	private Timber $timber;
 
-	/**
-	 * Class Constructor.
-	 *
-	 * @param Container $container The PHP DI Container.
-	 */
-	public function __construct( Container $container ) {
-		$this->container = $container;
-	}
 
 	/**
 	 * Loads custom Gutenberg blocks.
@@ -51,7 +45,7 @@ class Loader {
 
 			$full_class_path = sprintf( __NAMESPACE__ . '\%s\%s', $class, $class );
 			if ( method_exists( $full_class_path, 'init' ) ) {
-				( new $full_class_path( $this->container ) )->init();
+				( new $full_class_path( $this->timber ) )->init();
 			}
 		}
 	}

--- a/src/class-asset.php
+++ b/src/class-asset.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Somoscuatro\Starter_Theme;
 
+use DI\Attribute\Inject;
 use Somoscuatro\Starter_Theme\Attributes\Action;
 use Somoscuatro\Starter_Theme\Helpers\Filesystem;
 
@@ -24,16 +25,8 @@ class Asset {
 	 *
 	 * @var Theme
 	 */
-	protected $theme;
-
-	/**
-	 * Class Constructor.
-	 *
-	 * @param Theme $theme The Theme Class.
-	 */
-	public function __construct( Theme $theme ) {
-		$this->theme = $theme;
-	}
+	#[Inject]
+	protected Theme $theme;
 
 	/**
 	 * Enqueues Frontend Theme Styles and Scripts.

--- a/src/class-theme.php
+++ b/src/class-theme.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Somoscuatro\Starter_Theme;
 
+use DI\Attribute\Inject;
+
 use Somoscuatro\Starter_Theme\Attributes\Action;
 use Somoscuatro\Starter_Theme\Attributes\Filter;
 
@@ -26,21 +28,24 @@ class Theme {
 	 *
 	 * @var CustomPostTypesLoader
 	 */
-	private $custom_post_types_loader;
+	#[Inject]
+	private CustomPostTypesLoader $custom_post_types_loader;
 
 	/**
 	 * The Custom_Taxonomies\Loader Instance.
 	 *
 	 * @var CustomTaxonomiesLoader
 	 */
-	private $custom_taxonomies_loader;
+	#[Inject]
+	private CustomTaxonomiesLoader $custom_taxonomies_loader;
 
 	/**
 	 * The Blocks\Loader Instance.
 	 *
 	 * @var BlocksLoader
 	 */
-	private $blocks_loader;
+	#[Inject]
+	private BlocksLoader $blocks_loader;
 
 	/**
 	 * Theme Naming Prefix.
@@ -48,23 +53,6 @@ class Theme {
 	 * @var string
 	 */
 	private $prefix = 'starter_theme';
-
-	/**
-	 * Class Constructor.
-	 *
-	 * @param CustomPostTypesLoader  $custom_post_types_loader Custom_Post_Types\Loader Instance.
-	 * @param CustomTaxonomiesLoader $custom_taxonomies_loader Custom_Taxonomies\Loader Instance.
-	 * @param BlocksLoader           $blocks_loader Blocks\Loader Instance.
-	 */
-	public function __construct(
-		CustomPostTypesLoader $custom_post_types_loader,
-		CustomTaxonomiesLoader $custom_taxonomies_loader,
-		BlocksLoader $blocks_loader
-	) {
-		$this->custom_post_types_loader = $custom_post_types_loader;
-		$this->custom_taxonomies_loader = $custom_taxonomies_loader;
-		$this->blocks_loader            = $blocks_loader;
-	}
 
 	/**
 	 * Initialization method.


### PR DESCRIPTION
Experiment to use PHP attributes to inject required dependencies. Implemented attending to [PHP-DI documentation](https://php-di.org/doc/attributes.html).

Possible improvements:
- Better performance compiling the dependencies container [as documented here](https://php-di.org/doc/performances.html).