### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ Our code standards adhere to the guidelines established by the WordPress
 community. To ensure these standards are consistently applied, we utilize a
 suite of code quality tools:
 
-- [PHPCS (PHP CodeSniffer)](https://github.com/squizlabs/PHP_CodeSniffer)
+- [PHPCS (PHP CodeSniffer)](https://github.com/PHPCSStandards/PHP_CodeSniffer)
 - [ESLint](https://eslint.org/)
 - [Stylelint](https://stylelint.io/)
 - [Prettier](https://prettier.io/)


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932